### PR TITLE
Adding support for Circle-CI testing of latest Ubuntu (i.e Linux)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,42 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/pkcs11
+    docker:
+      - image: circleci/ubuntu-server:latest
+        environment:
+          CI: cicleci
+          DEBIAN_FRONTEND: noninteractive
+          CC: clang
+    branches:
+      only:
+        - master
+        - Circle-CI-Support
+    steps:
+      - run:
+          name: "clean apt"
+          command: |
+            sudo apt-get autoclean ; wait ;
+      - run:
+          name: "configure apt repo"
+          command: |
+            sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test" ; wait ;
+      - run:
+          name: "update apt"
+          command: |
+            sudo apt-get -yq update ; wait ;
+      - run:
+          name: "install dependencies"
+          command: |
+            sudo apt-get -y install build-essential libssl-dev openssl libengine-pkcs11-openssl libnss3 libnss3-tools libnss3-dev libtool clang autotools-dev automake make autoconf git openssh-client pkg-config ; wait ;
+      - checkout
+      - run:
+          name: "fetch and pull"
+          command: |
+            git fetch && git pull --all || true
+      - run:
+          shell: /bin/bash
+          name: "Tests"
+          command: |
+            .circleci/run_ci.sh
+destination: build

--- a/.circleci/run_ci.sh
+++ b/.circleci/run_ci.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+$CC --version
+echo "START OF BUILD"
+autoreconf -i
+./configure
+make V=1
+echo "END OF BUILD"
+echo ""
+echo "START OF TESTING"
+echo ""
+make test || exit $?
+echo ""
+echo "END OF TESTING"
+make test-clean
+
+exit 0
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 branches:
   only:
     - master
-    - Circle-CI-Support
 
 cache: apt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 branches:
   only:
     - master
+    - Circle-CI-Support
 
 cache: apt
 
@@ -17,6 +18,9 @@ addons:
     - gcc-6
     - libnss3-dev
     - libtool
+
+env:
+  - MATRIX_EVAL="true"
 
 matrix:
   include:
@@ -38,21 +42,30 @@ matrix:
     compiler: clang
     osx_image: xcode8
   - os: osx
-    env: INSTALL=gcc
     compiler: gcc-6
+    env:
+      - MATRIX_EVAL="brew install gcc6 && CC=gcc-6 && CXX=g++-6"
     osx_image: xcode8
+  - os: osx
+    compiler: clang
+    osx_image: xcode9
 
 before_install:
   - if [ $TRAVIS_OS_NAME == osx ] ; then
+       eval "${MATRIX_EVAL}" ;
        brew uninstall libtool ;
        brew install nss openssl automake autoconf libtool $INSTALL || true ;
     fi
 
-script:
+before_script:
   - $CC --version
+
+script:
   - autoreconf -i
   - if [ $TRAVIS_OS_NAME == osx ] ; then ./configure --with-openssl=/usr/local/Cellar/openssl/* ; fi
   - if [ $TRAVIS_OS_NAME == linux ] ; then ./configure ; fi
   - make V=1
   - make test
+
+after_script:
   - make test-clean

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
-pkcs11-util
-===========
+pkcs11-util CI fork
+===================
 
 __pkcs11-util__ is a small tool to access cryptographic tokens through
 the PKCS#11 API.
 
+Upstream:
 [![Build Status](https://travis-ci.org/mbrossard/pkcs11.svg?branch=master)](https://travis-ci.org/mbrossard/pkcs11)
 [![Build status](https://ci.appveyor.com/api/projects/status/892m1yi8vmx9rmdh?svg=true)](https://ci.appveyor.com/project/mbrossard/pkcs11)
+
+Fork:
+[![Build Status](https://travis-ci.org/reactive-firewall/pkcs11.svg?branch=master)](https://travis-ci.org/reactive-firewall/pkcs11)
+[![CircleCI](https://circleci.com/gh/reactive-firewall/pkcs11/tree/master.svg?style=svg)](https://circleci.com/gh/reactive-firewall/pkcs11/tree/master)
 
 == `pkcs11d` and `libpkcs11d`
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-pkcs11-util CI fork
-===================
+pkcs11-util
+===========
 
 __pkcs11-util__ is a small tool to access cryptographic tokens through
 the PKCS#11 API.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,9 @@ pkcs11-util CI fork
 __pkcs11-util__ is a small tool to access cryptographic tokens through
 the PKCS#11 API.
 
-Upstream:
 [![Build Status](https://travis-ci.org/mbrossard/pkcs11.svg?branch=master)](https://travis-ci.org/mbrossard/pkcs11)
 [![Build status](https://ci.appveyor.com/api/projects/status/892m1yi8vmx9rmdh?svg=true)](https://ci.appveyor.com/project/mbrossard/pkcs11)
-
-Fork:
-[![Build Status](https://travis-ci.org/reactive-firewall/pkcs11.svg?branch=master)](https://travis-ci.org/reactive-firewall/pkcs11)
-[![CircleCI](https://circleci.com/gh/reactive-firewall/pkcs11/tree/master.svg?style=svg)](https://circleci.com/gh/reactive-firewall/pkcs11/tree/master)
+[![CircleCI](https://circleci.com/gh/mbrossard/pkcs11/tree/master.svg?style=svg)](https://circleci.com/gh/mbrossard/pkcs11/tree/master)
 
 == `pkcs11d` and `libpkcs11d`
 

--- a/configure.ac
+++ b/configure.ac
@@ -80,7 +80,8 @@ if test x"$pkcs11_module" == x""; then
            if test `uname` == "Darwin" ; then
               pkcs11_module=`ls -1 /usr/local/Cellar/nss/*/lib/libsoftokn3.dylib | sort | tail -1` ;
            else
-              pkcs11_module=`ls -1 /usr/lib*/*/nss/libsoftokn3.so | sort | tail -1` ;
+              # pkcs11_module=`ls -1 /usr/lib*/*/nss/libsoftokn3.so | sort | tail -1` ;
+              pkcs11_module=`find /usr/ -ipath "*/nss/*" -a -iname libsoftokn3.so 2>/dev/null | sort | tail -1` ;
            fi
        fi
    fi


### PR DESCRIPTION
Pull Request to add testing against newer Linux versions via Circle-CI free test service.
- [x] added files for Circle-CI tests (with low change impact)
    - see https://github.com/reactive-firewall/pkcs11/pull/1 for more details
- [x] tested Circle-CI builds and regression tested and fixed Travis-CI builds
- [x] added badge for maintainer ( @mbrossard ) for Circle-CI (pending enable)
    - Test badge on fork: [![CircleCI](https://circleci.com/gh/reactive-firewall/pkcs11/tree/master.svg?style=svg)](https://circleci.com/gh/reactive-firewall/pkcs11/tree/master)
    - see https://circleci.com/gh/reactive-firewall/pkcs11/24 for build details
    - Final Merge badge code (pending enable): 
```markedown
[![CircleCI](https://circleci.com/gh/mbrossard/pkcs11/tree/master.svg?style=svg)](https://circleci.com/gh/mbrossard/pkcs11/tree/master)
```

https://github.com/reactive-firewall/pkcs11/blob/cae36700e1e3ebe3aeb0b137794d9c890efc1b36/README.md#L9

- [x] added support for latest Mac OS (`Xcode 9` image) tests via Travis-CI
    - see build https://travis-ci.org/reactive-firewall/pkcs11/builds/278459295 for details

@mbrossard 
Please review and or approve build details and changes. If some changes are unacceptable please advise as to what and why, so that any style or design considerations can be addressed.